### PR TITLE
make_ssh_key: change private key reading permissions.

### DIFF
--- a/src/backupfriend/make_ssh_key.py
+++ b/src/backupfriend/make_ssh_key.py
@@ -1,30 +1,32 @@
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
-import os.path
+import os
 from backupfriend.common import ensure_dir
 
 
 def generate_keys(path):
     # generate private/public key pair
     key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
-    
+
     # get public key in OpenSSH format
     public_key = key.public_key().public_bytes(serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH)
-    
+
     # get private key in PEM container format
     pem = key.private_bytes(encoding=serialization.Encoding.PEM,
                             format=serialization.PrivateFormat.TraditionalOpenSSL,
                             encryption_algorithm=serialization.NoEncryption())
-    
+
     # decode to printable strings
     private_key_str = pem.decode('utf-8')
     public_key_str = public_key.decode('utf-8')
 
     ensure_dir(path)
 
-    with open(os.path.join(path, "id_rsa"), "w") as w:
+    private_key_path = os.path.join(path, "id_rsa")
+    with open(private_key_path, "w") as w:
         w.write(private_key_str)
+    os.chmod(private_key_path, 0o600)
     with open(os.path.join(path, "id_rsa.pub"), "w") as w:
         w.write(public_key_str)
 


### PR DESCRIPTION
Default file permissions are 0o644, which is unacceptable by linux's SSH.
Change permissions to 0o600.

This is supposed to solve Issue #5 .