### PR TITLE
main.xrc, main.fbp: change default port and destination values.

### DIFF
--- a/src/backupfriend/res/main.fbp
+++ b/src/backupfriend/res/main.fbp
@@ -2341,12 +2341,12 @@
                                 <property name="style"></property>
                                 <property name="subclass">; ; forward_declare</property>
                                 <property name="toolbar_pane">0</property>
-                                <property name="tooltip">user@hostname.com::/folder</property>
+                                <property name="tooltip">Location for backing up your files</property>
                                 <property name="validator_data_type"></property>
                                 <property name="validator_style">wxFILTER_NONE</property>
                                 <property name="validator_type">wxDefaultValidator</property>
                                 <property name="validator_variable"></property>
-                                <property name="value">user@hostname.com::/folder</property>
+                                <property name="value">user@backupfriend.local::/backup</property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
@@ -2445,7 +2445,7 @@
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
-                                <property name="initial">22</property>
+                                <property name="initial">8022</property>
                                 <property name="max">65535</property>
                                 <property name="max_size"></property>
                                 <property name="maximize_button">0</property>

--- a/src/backupfriend/res/main.xrc
+++ b/src/backupfriend/res/main.xrc
@@ -378,8 +378,8 @@
 						<flag>wxALL|wxEXPAND</flag>
 						<border>5</border>
 						<object class="wxTextCtrl" name="m_dest">
-							<tooltip>user@hostname.com::/folder</tooltip>
-							<value>user@hostname.com::/folder</value>
+							<tooltip>Location for backing up your files</tooltip>
+							<value>user@backupfriend.local::/backup</value>
 						</object>
 					</object>
 					<object class="sizeritem">
@@ -397,7 +397,7 @@
 						<border>5</border>
 						<object class="wxSpinCtrl" name="m_port">
 							<style>wxSP_ARROW_KEYS</style>
-							<value>22</value>
+							<value>8022</value>
 							<min>0</min>
 							<max>65535</max>
 						</object>


### PR DESCRIPTION
Should resolve issue #9.

* Changed default backup port from 22 to 8022
* Changed default backup location from `user@hostname.com::/folder` to `user@backupfriend.local::/backup`, and added an informative tooltip.

Tested that port, destination and tooltip appears correctly on Linux.

NOTE: Change was done manually, not through wx form builder.