### PR TITLE
main: find ssh executable if missing from config.

### DIFF
--- a/src/backupfriend/main.py
+++ b/src/backupfriend/main.py
@@ -48,7 +48,7 @@ def save_config():
 
 config = get_config()
 
-if "ssh" not in config["main"]:
+if "ssh" not in config["main"] and "win" not in sys.platform:
     ssh = subprocess.run(['which', 'ssh'], capture_output=True, text=True).stdout.strip()
     config["main"]["ssh"] = ssh
     save_config()

--- a/src/backupfriend/main.py
+++ b/src/backupfriend/main.py
@@ -42,9 +42,16 @@ def get_config():
         return yaml.load(f, Loader=yaml.FullLoader)
     return
 
+def save_config():
+    with open(CONFIG_PATH, 'w') as f:
+        yaml.safe_dump(config, f)
 
 config = get_config()
 
+if "ssh" not in config["main"]:
+    ssh = subprocess.run(['which', 'ssh'], capture_output=True, text=True).stdout.strip()
+    config["main"]["ssh"] = ssh
+    save_config()
 
 def _run_command(command, **kwargs):
     if debug:
@@ -575,8 +582,7 @@ class MainInvisibleWindow(wx.Frame):
             self.sync_jobs.append(backup_class)
 
         if not in_config:
-             with open(CONFIG_PATH, 'w') as f:
-                 yaml.safe_dump(config, f)
+            save_config()
 
         pub.sendMessage(CFG_UPDATE_MSG)
 


### PR DESCRIPTION
Should fix issue #7. 

On Linux and Mac, default config does not define the location of the SSH executable.
Locate the ssh executable and save it in the config.